### PR TITLE
fix libselinux python package install to work with centos8

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: Ensure that the selinux packages are installed
   yum:
     name:
-      - libselinux-python
+      - "{{ ( (ansible_facts.distribution_major_version | int) < 8) | ternary('libselinux-python','python3-libselinux') }}"
       - selinux-policy
     state: present
 


### PR DESCRIPTION
Hey Pablo,
while working on a CentOS 8 machine I realized that `libselinux-python` is also used in this role, and in CentOS 8 they have a new package name `python3-libselinux`. I have used the same fix as what was used in wcm-io-devops apache role (https://github.com/wcm-io-devops/ansible-role-apache/blob/c798a30e372ae5143150e9ae0ecf3c760686f99b/tasks/configure-RedHat.yml#L5)


Regards,
Iñaki
